### PR TITLE
change the way maxIndex is calculated

### DIFF
--- a/netrc.js
+++ b/netrc.js
@@ -98,9 +98,7 @@ NetRC.prototype.addMachine = function (hostname, options) {
     }
 
     var self = this,
-        maxIndex = Math.max.apply(null, Object.keys(this.machines).map(function (key) {
-            return self.machines[key].index;
-        })) || 0,
+        maxIndex = Object.keys(self.machines).length || 0,
         machine;
 
     if (this.machines[hostname]) this.error("Machine " + hostname + " already exists in " + this.filename);

--- a/netrc.js
+++ b/netrc.js
@@ -61,7 +61,9 @@ NetRC.prototype.read = function() {
             key = null;
         }
     }
-    this.machines[machine.machine] = machine;
+    if (machine && machine.machine) {
+        this.machines[machine.machine] = machine;
+    }
 };
 
 NetRC.prototype.write = function() {

--- a/test/netrc.test.js
+++ b/test/netrc.test.js
@@ -7,12 +7,14 @@ describe('netrc', function () {
 
   var netrc,
       inputFilename,
+      emptyFilename,
       outputFilename;
 
   beforeEach(function () {
     netrc = new NetRC();
     inputFilename = path.join(__dirname, '.netrc');
     outputFilename = path.join(__dirname, '.netrc-modified');
+    emptyFilename = path.join(__dirname, '.netrc-empty');
     fs.writeFileSync(outputFilename, fs.readFileSync(inputFilename, { encoding: 'utf8' }));
   });
 
@@ -33,6 +35,10 @@ describe('netrc', function () {
     assert.equal(netrc.host("api.example.com").password, "86802bc8abbffd7fa4f203329ba55c4043f4db78");
     assert.equal(netrc.host("git.example.com").login, "alice@git.example.com");
     assert.equal(netrc.host("git.example.com").password, "86803bc8abbffd7fa4f203329ba55c4043f4db78");
+
+    netrc.file(emptyFilename);
+    netrc.read();
+    assert.deepEqual(netrc.machines, {});
   });
 
   it("knows if a machine is in the .netrc", function () {
@@ -70,6 +76,27 @@ describe('netrc', function () {
     var original = fs.readFileSync(inputFilename, { encoding: 'utf8' }),
         modified = original +
           "\nmachine new.example.com\n" +
+          "  login alice@new.example.com\n" +
+          "  password p@ssword";
+
+    netrc.addMachine("new.example.com", {
+      login: "alice@new.example.com",
+      password: "p@ssword"
+    });
+
+    netrc.file(outputFilename);
+    netrc.write();
+
+    assert.equal(fs.readFileSync(outputFilename, { encoding: 'utf8' }), modified);
+  });
+
+  it("modifies and writes originally empty .netrc file", function () {
+    netrc.file(emptyFilename);
+    netrc.read();
+
+    var original = '',
+        modified = original +
+          "machine new.example.com\n" +
           "  login alice@new.example.com\n" +
           "  password p@ssword";
 


### PR DESCRIPTION
currently if `.netrc` file is empty `Math.max.apply(null, [])` will return `-Infinity` which is a truthy value.
then if you try to add a machine it will not write it correctly because index will be `-Infinity`
