### PR TITLE
Allow to check if the .netrc file is readable (thus exists)

### DIFF
--- a/netrc.js
+++ b/netrc.js
@@ -26,6 +26,16 @@ NetRC.prototype.hasHost = function (hostname) {
     return !!this.machines[hostname]
 };
 
+NetRC.prototype.isConfigReadable = function() {
+    try {
+        var fd = fs.openSync(this.filename, 'r');
+        fs.closeSync(fd);
+    } catch (e) {
+        return false;
+    }
+    return true;
+};
+
 NetRC.prototype.read = function() {
     if (!fs.existsSync(this.filename)) this.error("File does not exist: " + this.filename);
     this.machines = {};

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "netrc-rw",
-  "version": "0.1.3",
+  "version": "0.1.4",
   "description": ".netrc reader and writer",
   "main": "netrc.js",
   "directories": {

--- a/package.json
+++ b/package.json
@@ -16,6 +16,11 @@
   "keywords": [
     "netrc"
   ],
+  "config": {
+    "test": {
+      "permissions": false
+    }
+  },
   "author": {
     "name": "JD Brennan",
     "email": "jazzdev@gmail.com"

--- a/test/.netrc-private
+++ b/test/.netrc-private
@@ -1,0 +1,9 @@
+machine code.example.com
+  login alice@code.example.com
+  password 86801bc8abbffd7fa4f203329ba55c4043f4db78
+machine api.example.com
+  login alice@api.example.com
+  password 86802bc8abbffd7fa4f203329ba55c4043f4db78
+machine git.example.com
+  login alice@git.example.com
+  password 86803bc8abbffd7fa4f203329ba55c4043f4db78

--- a/test/netrc.test.js
+++ b/test/netrc.test.js
@@ -1,20 +1,23 @@
 var assert = require('assert'),
     path = require('path'),
     fs = require('fs'),
-    NetRC = require('..').NetRC;
+    NetRC = require('..').NetRC,
+    pkg = require('../package.json');
 
 describe('netrc', function () {
 
   var netrc,
       inputFilename,
       emptyFilename,
-      outputFilename;
+      outputFilename,
+      privateFilename;
 
   beforeEach(function () {
     netrc = new NetRC();
     inputFilename = path.join(__dirname, '.netrc');
     outputFilename = path.join(__dirname, '.netrc-modified');
     emptyFilename = path.join(__dirname, '.netrc-empty');
+    privateFilename = path.join(__dirname, '.netrc-private');
     fs.writeFileSync(outputFilename, fs.readFileSync(inputFilename, { encoding: 'utf8' }));
   });
 
@@ -112,5 +115,28 @@ describe('netrc', function () {
 
     assert.equal(fs.readFileSync(outputFilename, { encoding: 'utf8' }), modified);
   });
+
+  it("checks if the input netrc file exists and is readable", function () {
+    netrc.file(inputFilename);
+    var isConfigReadable = netrc.isConfigReadable();
+    assert.equal(isConfigReadable, true);
+  })
+
+  it("checks if the non-existing input netrc file exists and is readable", function () {
+    netrc.file('.netrc-non-existing-' + (Math.round(Math.random() * 10000)));
+    var isConfigReadable = netrc.isConfigReadable();
+    assert.equal(isConfigReadable, false);
+  })
+
+  if (pkg.config.test.permissions) {
+    it("checks if the non-existing input netrc file exists and is readable", function () {
+      netrc.file(privateFilename);
+      var isConfigReadable = netrc.isConfigReadable();
+      if (isConfigReadable === true) {
+        console.log('ATTENTION: Make sure to change the owner of the .netrc-private and the mode to 0600.');
+      }
+      assert.equal(isConfigReadable, false);
+    })
+  }
 
 });

--- a/test/netrc.test.js
+++ b/test/netrc.test.js
@@ -129,7 +129,7 @@ describe('netrc', function () {
   })
 
   if (pkg.config.test.permissions) {
-    it("checks if the non-existing input netrc file exists and is readable", function () {
+    it("checks if the existing input netrc file is not readable due to permissions", function () {
       netrc.file(privateFilename);
       var isConfigReadable = netrc.isConfigReadable();
       if (isConfigReadable === true) {


### PR DESCRIPTION
Useful if one's project has fallback methods to gather the credentials.
